### PR TITLE
install unbound from CentOS6 Continuous Release Repository

### DIFF
--- a/fullbok.template
+++ b/fullbok.template
@@ -286,8 +286,14 @@
           "#! /bin/bash -v\n",
           "yum update -y\n",
 
+          "# Continuous Release Repository setting for unbound\n",
+          "wget http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-cr-6-0.el6.centos.x86_64.rpm\n",
+          "rpm -ivh --nodeps centos-release-cr-6-0.el6.centos.x86_64.rpm\n",
+          "sed -i 's/centos\/.*\/cr/centos\/6\/cr/g' /etc/yum.repos.d/CentOS-CR.repo\n",
+          "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-CR.repo\n",
+
           "# Install local dns resolver\n",
-          "yum install -y --enablerepo=epel unbound\n",
+          "yum install -y --enablerepo=cr unbound\n",
           "sed -i 's/val-permissive-mode: .*/val-permissive-mode: yes/g' /etc/unbound/unbound.conf\n",
           "echo -e 'forward-zone:\n\tname: ", { "Ref": "AWS::Region" } ,".compute.internal\n\tforward-addr: 10.0.0.2' >> /etc/unbound/unbound.conf\n",
           "service unbound start\n",

--- a/fullbok.template
+++ b/fullbok.template
@@ -289,8 +289,8 @@
           "# Continuous Release Repository setting for unbound\n",
           "wget http://mirror.centos.org/centos/6/extras/x86_64/Packages/centos-release-cr-6-0.el6.centos.x86_64.rpm\n",
           "rpm -ivh --nodeps centos-release-cr-6-0.el6.centos.x86_64.rpm\n",
-          "sed -i 's/centos\/.*\/cr/centos\/6\/cr/g' /etc/yum.repos.d/CentOS-CR.repo\n",
-          "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-CR.repo\n",
+          "sed -i 's/$releasever/6/g' /etc/yum.repos.d/CentOS-CR.repo\n",
+          "sed -i 's/=1/=0/g' /etc/yum.repos.d/CentOS-CR.repo\n",
 
           "# Install local dns resolver\n",
           "yum install -y --enablerepo=cr unbound\n",


### PR DESCRIPTION
https://github.com/classmethod-aws/fullbok/issues/10

の問題に対処するため、epelからではなく、crからunboundを入れるように修正してみました。
動作も確認済みです。

amazonlinux、epel、crが今後どうなるのかで、いつまでコードが有効か分かりませんが、プルリク出しておきます。
