### PR TITLE
Fix unbound installation

### DIFF
--- a/fullbok.template
+++ b/fullbok.template
@@ -287,7 +287,8 @@
           "yum update -y\n",
 
           "# Install local dns resolver\n",
-          "yum install -y --enablerepo=epel unbound\n",
+          "printf '[centos-extras]\nname=CentOS-6 - Extras\nmirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=extras\nenabled=0\ngpgcheck=0\n' > /etc/yum.repos.d/CentOS-Extras.repo\n",
+          "yum install -y --enablerepo=centos-extras unbound\n",
           "sed -i 's/val-permissive-mode: .*/val-permissive-mode: yes/g' /etc/unbound/unbound.conf\n",
           "echo -e 'forward-zone:\n\tname: ", { "Ref": "AWS::Region" } ,".compute.internal\n\tforward-addr: 10.0.0.2' >> /etc/unbound/unbound.conf\n",
           "service unbound start\n",


### PR DESCRIPTION
## 何を実装したか

#10 で報告されているようにunboundがEPELからインストールできない問題を修正するため。 #12 でPRが出されていますが、自分が検証した限り上手くインストールできなかったので、別のPRを作成。

## どうやって実装したか

CentOS6のextrasリポジトリの情報を/etc/yum.repos.d以下に作成、 `--enablerepo` オプションを付けてyumからインストールという流れ。

## どうやってPRの検証ができるか

修正したテンプレートで作成したスレーブインスタンスの各種情報を添付します。

- `/var/log/cloud-init-output.log` よりunbound周りを抜粋

```bash
# Install local dns resolver
printf '[centos-extras]
name=CentOS-6 - Extras
mirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=extras
enabled=0
gpgcheck=0
' > /etc/yum.repos.d/CentOS-Extras.repo
yum install -y --enablerepo=centos-extras unbound
Loaded plugins: priorities, update-motd, upgrade-helper
Existing lock /var/run/yum.pid: another copy is running as pid 7506.
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory :  23 M RSS (345 MB VSZ)
    Started: Sat Jan 14 03:18:32 2017 - 00:07 ago
    State  : Sleeping, pid: 7506
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory :  59 M RSS (380 MB VSZ)
    Started: Sat Jan 14 03:18:32 2017 - 00:09 ago
    State  : Running, pid: 7506
2 packages excluded due to repository priority protections
Resolving Dependencies
--> Running transaction check
---> Package unbound.x86_64 0:1.4.20-23.el6.1 will be installed
--> Processing Dependency: unbound-libs(x86-64) = 1.4.20-23.el6.1 for package: unbound-1.4.20-23.el6.1.x86_64
--> Processing Dependency: libunbound.so.2()(64bit) for package: unbound-1.4.20-23.el6.1.x86_64
--> Processing Dependency: libldns.so.1()(64bit) for package: unbound-1.4.20-23.el6.1.x86_64
--> Processing Dependency: libevent-1.4.so.2()(64bit) for package: unbound-1.4.20-23.el6.1.x86_64
--> Running transaction check
---> Package compat-libevent.x86_64 0:1.4.13-4.10.amzn1 will be installed
---> Package ldns.x86_64 0:1.6.16-7.el6.1 will be installed
---> Package unbound-libs.x86_64 0:1.4.20-23.el6.1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package             Arch       Version                 Repository         Size
================================================================================
Installing:
 unbound             x86_64     1.4.20-23.el6.1         centos-extras     1.0 M
Installing for dependencies:
 compat-libevent     x86_64     1.4.13-4.10.amzn1       amzn-main         115 k
 ldns                x86_64     1.6.16-7.el6.1          centos-extras     444 k
 unbound-libs        x86_64     1.4.20-23.el6.1         centos-extras     303 k

Transaction Summary
================================================================================
Install  1 Package (+3 Dependent packages)

Total download size: 1.9 M
Installed size: 5.2 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              1.7 MB/s | 1.9 MB  00:01
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : compat-libevent-1.4.13-4.10.amzn1.x86_64                     1/4
  Installing : ldns-1.6.16-7.el6.1.x86_64                                   2/4
  Installing : unbound-libs-1.4.20-23.el6.1.x86_64                          3/4
  Installing : unbound-1.4.20-23.el6.1.x86_64                               4/4
  Verifying  : ldns-1.6.16-7.el6.1.x86_64                                   1/4
  Verifying  : unbound-1.4.20-23.el6.1.x86_64                               2/4
  Verifying  : compat-libevent-1.4.13-4.10.amzn1.x86_64                     3/4
  Verifying  : unbound-libs-1.4.20-23.el6.1.x86_64                          4/4

Installed:
  unbound.x86_64 0:1.4.20-23.el6.1

Dependency Installed:
  compat-libevent.x86_64 0:1.4.13-4.10.amzn1    ldns.x86_64 0:1.6.16-7.el6.1
  unbound-libs.x86_64 0:1.4.20-23.el6.1

Complete!
sed -i 's/val-permissive-mode: .*/val-permissive-mode: yes/g' /etc/unbound/unbound.conf
echo -e 'forward-zone:
        name: ap-northeast-1.compute.internal
        forward-addr: 10.0.0.2' >> /etc/unbound/unbound.conf
service unbound start
Generating unbound control key and certificate:
Starting unbound: Jan 14 03:18:52 unbound[7587:0] warning: increased limit(open files) from 1024 to 8290
[  OK  ]
chkconfig unbound on
sed -i 's/PEERDNS=yes/PEERDNS=no/g' /etc/sysconfig/network-scripts/ifcfg-eth0
sed -i 's/nameserver .*/nameserver 127.0.0.1/g' /etc/resolv.conf
```

- インストールされるunboundのバージョン

```bash
$ unbound -h
usage:  unbound [options]
        start unbound daemon DNS resolver.
-h      this help
-c file config file to read instead of /etc/unbound/unbound.conf
        file format is described in unbound.conf(5).
-d      do not fork into the background.
-v      verbose (more times to increase verbosity)
Version 1.4.20
linked libs: libevent 1.4.13-stable (it uses epoll), ldns 1.6.16, OpenSSL 1.0.1k-fips 8 Jan 2015
linked modules: python validator iterator
configured for x86_64-redhat-linux-gnu on Tue Sep 22 17:55:32 UTC 2015 with options: '--build=x86_64-redhat-linux-gnu' '--host=x86_64-redhat-linux-gnu' '--target=x86_64-redhat-linux-gnu' '--program-prefix=' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib64' '--libexecdir=/usr/libexec' '--localstatedir=/var' '--sharedstatedir=/var/lib' '--mandir=/usr/share/man' '--infodir=/usr/share/info' '--with-ldns' '--with-libevent' '--with-pthreads' '--with-ssl' '--disable-rpath' '--disable-static' '--with-conf-file=/etc/unbound/unbound.conf' '--with-pidfile=/var/run/unbound/unbound.pid' '--with-pythonmodule' '--with-pyunbound' '--enable-sha2' '--disable-gost' '--enable-ecdsa' '--with-rootkey-file=/var/lib/unbound/root.key'
BSD licensed, see LICENSE in source package for details.
Report bugs to unbound-bugs@nlnetlabs.nl
```
