### PR TITLE
Add Stack Name to EC2 Name Tag

### DIFF
--- a/fullbok.template
+++ b/fullbok.template
@@ -263,7 +263,7 @@
         "MaxSize" : { "Ref" : "SlaveCapacity" },
         "DesiredCapacity" : { "Ref" : "SlaveCapacity" },
         "Tags" : [
-          { "Key" : "Name", "Value" : "JMeterSlave", "PropagateAtLaunch" : "true" },
+          { "Key" : "Name", "Value" : { "Fn::Join" : [ "-", [ { "Ref" : "AWS::StackName" },  "JMeterSlave" ]]}, "PropagateAtLaunch" : "true" },
           { "Key" : "Network", "Value" : "Public", "PropagateAtLaunch" : "true" }
         ]
       }
@@ -435,7 +435,7 @@
         "IamInstanceProfile": { "Ref" : "PowerUserProfile" },
         "Monitoring" : "false",
         "Tags" : [
-          { "Key" : "Name", "Value" : "JMeterMaster" },
+          { "Key" : "Name", "Value" : { "Fn::Join" : [ "-", [ { "Ref" : "AWS::StackName" },  "JMeterMaster" ]]}},
           { "Key" : "Network", "Value" : "Public" }
         ],
         "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [


### PR DESCRIPTION
In order to distinguish even when launching multiple JMeter clusters,
add CloudFormation Stack Name to EC2 Name Tag.